### PR TITLE
Prepare to move Petri-Site repos to Petri

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository provides the website and source code for Apache Petri.
 - [info.yaml](info.yaml) -- Machine Readable Culture Status
 - [petri.rdf](content/petri.rdf) -- Machine Readable [Project DOAP](https://projects.apache.org/project.html?petri)
 - [Pages](content/pages) -- website pages in GitHub Markdown
-- [Issues](https://github.com/apache/petri-site/issues) -- tracker
+- [Issues](https://github.com/apache/petri/issues) -- tracker
 
 The website is built with [Pelican](https://blog.getpelican.com).
 CI/CD is via a [.asf.yaml file](https://cwiki.apache.org/confluence/display/INFRA/Git+-+.asf.yaml+features).

--- a/content/pages/buildstream.md
+++ b/content/pages/buildstream.md
@@ -54,7 +54,3 @@ https://buildstream.build/install.html
 ### Machine Readable Status
 
 - [info.yaml](https://github.com/apache/petri/blob/master/info.yaml)
-
-### Petri Website Markdown Source
-
-- [view source](https://github.com/apache/petri/blob/master/content/pages/buildstream.md)

--- a/content/pages/buildstream.md
+++ b/content/pages/buildstream.md
@@ -53,8 +53,8 @@ https://buildstream.build/install.html
 
 ### Machine Readable Status
 
-- [info.yaml](https://github.com/apache/petri-site/blob/master/info.yaml)
+- [info.yaml](https://github.com/apache/petri/blob/master/info.yaml)
 
 ### Petri Website Markdown Source
 
-- [view source](https://github.com/apache/petri-site/blob/master/content/pages/buildstream.md)
+- [view source](https://github.com/apache/petri/blob/master/content/pages/buildstream.md)

--- a/content/pages/cookbook.md
+++ b/content/pages/cookbook.md
@@ -55,8 +55,8 @@ A list of your current mentors.
 ### Machine Readable Status
 
 The status information for a community should also be updated in
-[info.yaml](https://github.com/apache/petri-site/blob/master/info.yaml).
+[info.yaml](https://github.com/apache/petri/blob/master/info.yaml).
 
 ### Petri Website Markdown Source
 
-- [view source](https://github.com/apache/petri-site/blob/master/content/pages/cookbook.md)
+- [view source](https://github.com/apache/petri/blob/master/content/pages/cookbook.md)

--- a/content/pages/cookbook.md
+++ b/content/pages/cookbook.md
@@ -56,7 +56,3 @@ A list of your current mentors.
 
 The status information for a community should also be updated in
 [info.yaml](https://github.com/apache/petri/blob/master/info.yaml).
-
-### Petri Website Markdown Source
-
-- [view source](https://github.com/apache/petri/blob/master/content/pages/cookbook.md)

--- a/content/pages/faq.md
+++ b/content/pages/faq.md
@@ -231,7 +231,3 @@ a community is unwilling to wait for graduation, and Petri has
 accepted them, then the Incubator will need to retire the podling.
 Petri will then take responsibility for the podling’s resources, and
 perform any needed changes to make that happen.
-
-### Petri Website Markdown Source
-
-- [view source](https://github.com/apache/petri/blob/master/content/pages/faq.md)

--- a/content/pages/faq.md
+++ b/content/pages/faq.md
@@ -234,4 +234,4 @@ perform any needed changes to make that happen.
 
 ### Petri Website Markdown Source
 
-- [view source](https://github.com/apache/petri-site/blob/master/content/pages/faq.md)
+- [view source](https://github.com/apache/petri/blob/master/content/pages/faq.md)

--- a/content/pages/index.md
+++ b/content/pages/index.md
@@ -49,7 +49,3 @@ Please read our [FAQ](/faq) or ask questions on discuss@petri.apache.org
 
 - [info.yaml](https://petri.apache.org/info.yaml)
 - [petri.rdf](https://projects.apache.org/project.html?petri)
-
-### Petri Website Markdown Source
-
-- [view source](https://github.com/apache/petri/blob/master/content/pages/index.md)

--- a/content/pages/index.md
+++ b/content/pages/index.md
@@ -42,8 +42,8 @@ Please read our [FAQ](/faq) or ask questions on discuss@petri.apache.org
 
 ## Petri Repositories and Issue Tracking
 
-- [Website](https://github.com/apache/petri-site)
-- [Issues](https://github.com/apache/petri-site/issues)
+- [Website](https://github.com/apache/petri)
+- [Issues](https://github.com/apache/petri/issues)
 
 ### Petri Status Files
 
@@ -52,4 +52,4 @@ Please read our [FAQ](/faq) or ask questions on discuss@petri.apache.org
 
 ### Petri Website Markdown Source
 
-- [view source](https://github.com/apache/petri-site/blob/master/content/pages/index.md)
+- [view source](https://github.com/apache/petri/blob/master/content/pages/index.md)

--- a/content/pages/mentors.md
+++ b/content/pages/mentors.md
@@ -19,4 +19,4 @@ for projects within the Apache Petri.
 
 ### Petri Website Markdown Source
 
-- [view source](https://github.com/apache/petri-site/blob/master/content/pages/mentors.md)
+- [view source](https://github.com/apache/petri/blob/master/content/pages/mentors.md)

--- a/content/pages/mentors.md
+++ b/content/pages/mentors.md
@@ -16,7 +16,3 @@ for projects within the Apache Petri.
 - Justin Erenkrantz (jerenkrantz)
 - Ross Gardler (rgardler)
 - Sander Striker (striker)
-
-### Petri Website Markdown Source
-
-- [view source](https://github.com/apache/petri/blob/master/content/pages/mentors.md)

--- a/content/pages/projects.md
+++ b/content/pages/projects.md
@@ -3,15 +3,15 @@ title: Projects mentored by Apache Petri
 
 ## Project Status
 
-- Machine readable status [petri.yaml](https://petri.apache.org/info.yaml) -- [source](https://github.com/apache/petri-site/blob/master/content/info.yaml)
-- [Cookbook](cookbook) -- [source](https://github.com/apache/petri-site/blob/master/content/pages/cookbook.md)
+- Machine readable status [petri.yaml](https://petri.apache.org/info.yaml) -- [source](https://github.com/apache/petri/blob/master/info.yaml)
+- [Cookbook](cookbook) -- [source](https://github.com/apache/petri/blob/master/content/pages/cookbook.md)
 
 ## Current Cultures
 
-- [BuildStream](buildstream) -- [source](https://github.com/apache/petri-site/blob/master/content/pages/buildstream.md)
+- [BuildStream](buildstream) -- [source](https://github.com/apache/petri/blob/master/content/pages/buildstream.md)
 
   BuildStream is an integration build system. It models dependencies at a project level, enabling projects to use their own underlying build system
 
 ### Petri Website Markdown Source
 
-- [view source](https://github.com/apache/petri-site/blob/master/content/pages/projects.md)
+- [view source](https://github.com/apache/petri/blob/master/content/pages/projects.md)

--- a/content/pages/projects.md
+++ b/content/pages/projects.md
@@ -11,7 +11,3 @@ title: Projects mentored by Apache Petri
 - [BuildStream](buildstream) -- [source](https://github.com/apache/petri/blob/master/content/pages/buildstream.md)
 
   BuildStream is an integration build system. It models dependencies at a project level, enabling projects to use their own underlying build system
-
-### Petri Website Markdown Source
-
-- [view source](https://github.com/apache/petri/blob/master/content/pages/projects.md)


### PR DESCRIPTION
Once Petri-Site Repository is renamed Petri then this PR should be applied.