### PR TITLE
feat(ci): add pre-commit Python framework

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,47 +32,18 @@ jobs:
         run: |
           # stop the build if there are Python syntax errors or undefined names
           flake8 . --count --ignore=E201,E501 --show-source --statistics
-  markdownlint:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os:
-          - ubuntu-latest
-        node_version:
-          - 14
-        architecture:
-          - x64
-    name: Markdown Node ${{ matrix.node_version }} - ${{ matrix.architecture }} on ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v2
-      - name: Setup node
-        uses: actions/setup-node@v2
-        with:
-          node-version: ${{ matrix.node_version }}
-          architecture: ${{ matrix.architecture }}
-      - run: npm install -g markdownlint-cli@0.27.1
-      - run: markdownlint '**/*.md'
   misspell:
-    name: Check Spelling
+    name: Check spelling all files in commit misspell
     runs-on: ubuntu-latest
     steps:
-      - name: Check Out
+      - name: Check out
         uses: actions/checkout@v2
       - name: Install
-        run: |
-          wget -O - -q https://git.io/misspell | sh -s -- -b .
-      - name: Misspell
-        run: |
-          git ls-files --empty-directory | xargs ./misspell -error
-  trailing-whitespace:
-    name: Trailing whitespace
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Check for trailing whitespace
-        run: "! git grep -EIn $'[ \t]+$'"
-  yamllint:
-    name: YAML
+        run: wget -O - -q https://git.io/misspell | sh -s -- -b .
+      - name: misspell
+        run: git ls-files --empty-directory | xargs ./misspell -error
+  pre-commit:
+    name: Run pre-commit
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -83,7 +54,12 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install yamllint
-      - name: YAML Lint
-        run: |
-          yamllint --strict .
+          pip install pre-commit
+      - name: Set PY
+        run: echo "PY=$(python -VV | sha256sum | cut -d' ' -f1)" >> $GITHUB_ENV
+      - uses: actions/cache@v1
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit|${{ env.PY }}|${{ hashFiles('.pre-commit-config.yaml') }}
+      - name: Run pre-commit
+        run: pre-commit run --all-files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,53 @@
+---
+# https://pre-commit.com/
+default_stages: [commit, push]
+default_language_version:
+  # force all unspecified Python hooks to run python3
+  python: python3
+minimum_pre_commit_version: "1.20.0"
+repos:
+  - repo: meta
+    hooks:
+      - id: identity
+      - id: check-hooks-apply
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.4.0
+    hooks:
+      - id: check-added-large-files
+      - id: check-case-conflict
+      - id: check-merge-conflict
+      - id: check-yaml
+      - id: end-of-file-fixer
+      - id: fix-byte-order-marker
+      - id: mixed-line-ending
+      - id: trailing-whitespace
+  # - repo: git://github.com/Lucas-C/pre-commit-hooks
+  #  rev: v1.1.9
+  #  hooks:
+  #    - id: forbid-tabs
+  #    - id: remove-tabs
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.0.0
+    hooks:
+      - id: codespell
+        name: Run codespell
+        description: Check spelling with codespell
+        entry: codespell --ignore-words=codespell.txt
+  - repo: https://github.com/igorshubovych/markdownlint-cli
+    rev: v0.27.1
+    hooks:
+      - id: markdownlint
+        name: Run markdownlint
+        description: Checks the style of Markdown files
+        entry: markdownlint -c .markdownlint.yaml .
+        types: [markdown]
+        files: \.(md|mdown|markdown)$
+  - repo: https://github.com/adrienverge/yamllint
+    rev: v1.26.1
+    hooks:
+      - id: yamllint
+        name: Run yamllint
+        description: Check YAML files with yamllint
+        entry: yamllint --strict -c .yamllint.yaml
+        types: [yaml]
+        files: \.(yaml|yml)$

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,4 +1,5 @@
 ---
+# https://yamllint.readthedocs.io/en/stable/
 
 extends: default
 

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -13,15 +13,46 @@ CSS frameworks available are:
 - [Bootstrap 4.3.1](https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.css)
 - [GitHub Markdown 3.0.1](https://cdnjs.cloudflare.com/ajax/libs/github-markdown-css/3.0.1/github-markdown.css)
 
-Additional testing with GitHub Actions:
+Testing with GitHub Actions:
 
 - [Lint](.github/workflows/lint.yml) -- [GitHub Actions](https://docs.github.com/en/actions) Workflow
 - [Flake8](https://flake8.pycqa.org/en/latest/) - [Python](https://www.python.org/) based tool for style guide enforcement
-- [markdownlint](https://github.com/DavidAnson/markdownlint) -- using [markdownlint-cli](https://github.com/igorshubovych/markdownlint-cli) - [Node.js](https://nodejs.org/) style checker and lint tool for [Markdown](https://daringfireball.net/projects/markdown/) and CommonMark files
 - [misspell](https://github.com/client9/misspell) -- [Golang](https://golang.org/) library to correct commonly misspelled English words quickly
-- [yamllint](https://yamllint.readthedocs.io/en/stable/) -- a linter for [YAML](https://yaml.org/) files
+- [pre-commit](https://pre-commit.com/) -- Python based Git Hooks made easy. Git hook scripts are useful for identifying simple issues before submission to code review. We run our hooks on every commit to automatically point out issues in code such as missing semicolons, trailing whitespace, and debug statements. By pointing these issues out before code review, this allows a code reviewer to focus on the architecture of a change while not wasting time with trivial style nitpicks
 
-For misspell you can pass in `-w` to autocorrect misspelled words. You can also autocorrect some markdownlint
+`pre-commit` can be [installed](https://pre-commit.com/#installation) with `pip`, `curl`, `brew` or `conda`.
+You need to first install `pre-commit` and then install the `pre-commit` hooks with `pre-commit install`.
+Now `pre-commit` will run automatically on git commit!
+
+It's usually a good idea to run the hooks against all the files when adding new hooks (usually `pre-commit` will only run on the changed files during git hooks).
+Use `pre-commit run --all-files` to check all files.
+
+To run a single hook use `pre-commit run --all-files <hook_id>`
+
+To update use `pre-commit autoupdate`
+
+- [Quick start](https://pre-commit.com/#quick-start)
+- [Usage](https://pre-commit.com/#usage)
+- [pre-commit autoupdate](https://pre-commit.com/#pre-commit-autoupdate)
+- [.pre-commit-config.yaml](.pre-commit-config.yaml)
+
+The `pre-commit` GitHub Action runs an array of simple checks as well three more common linters:
+
+- id: identity
+- id: check-hooks-apply
+- id: check-added-large-files
+- id: check-case-conflict
+- id: check-merge-conflict
+- id: check-yaml
+- id: end-of-file-fixer
+- id: fix-byte-order-marker
+- id: mixed-line-ending
+- id: trailing-whitespace
+- id: [codespell](https://github.com/codespell-project/codespell) -- Fix common misspellings in text files. It's designed primarily for checking misspelled words in source code, but it can be used with other files as well
+- id: [markdownlint](https://github.com/DavidAnson/markdownlint) -- using [markdownlint-cli](https://github.com/igorshubovych/markdownlint-cli) - [Node.js](https://nodejs.org/) style checker and lint tool for [Markdown](https://daringfireball.net/projects/markdown/) and CommonMark files
+- id: [yamllint](https://yamllint.readthedocs.io/en/stable/) -- a linter for [YAML](https://yaml.org/) files
+
+For `misspell` you can pass in `-w` to autocorrect misspelled words. You can also autocorrect some `markdownlint`
 errors by using the `--fix` flag.
 
 Developer Tools:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
+beautifulsoup4
 pelican
 pelican-sitemap
-beautifulsoup4


### PR DESCRIPTION
Official -> "Git hook scripts are useful for identifying simple issues before submission to code review. We run our hooks on every commit to automatically point out issues in code such as missing semicolons, trailing whitespace, and debug statements. By pointing these issues out before code review, this allows a code reviewer to focus on the architecture of a change while not wasting time with trivial style nitpicks."

https://pre-commit.com/

Adding `pre-commit` gives us a larger array of checks or tests and pre-commit runs on both the local machine and with GitHub Actions.  `pre-commit` speeds up development since it can automatically fix issues in commits and you don't have to wait for the GitHub Actions to run since it runs on your local machine really quickly and gives instant feedback.

`pre-commit` can be installed in multiple ways even with `pip` so in future could be added to the `requirements.txt`.  Also we are currently running `Flake8` on GitHub Actions and this can be moved to the `pre-commit` framework in future and maybe also added to the `requirements.txt`. 

Apache Airflow has a best in class `pre-commit` framework and Airflow is mainly written in Python.

https://github.com/apache/airflow/blob/master/.pre-commit-config.yaml

Running `pre-commit run --all-files` on this commit on my local machine:

<img width="894" alt="Screen Shot 2021-05-06 at 7 00 17 am" src="https://user-images.githubusercontent.com/418747/117210632-4c386580-ae3b-11eb-9c90-5e5f7e10d3f4.png">

<img width="893" alt="Screen Shot 2021-05-06 at 7 00 03 am" src="https://user-images.githubusercontent.com/418747/117210685-5d817200-ae3b-11eb-8064-d69b13581434.png">